### PR TITLE
Update Date.php

### DIFF
--- a/src/DataForm/Field/Date.php
+++ b/src/DataForm/Field/Date.php
@@ -42,12 +42,8 @@ class Date extends Field
         $isodate = str_replace(" 00:00:00", "", $isodate);
         $datetime = \DateTime::createFromFormat( 'Y-m-d', $isodate);
         if (!$datetime) return '';
-        $timestamp = $datetime->getTimestamp();
-        if ($timestamp < 1) {
-            return "";
-        }
-        $isodate = date($this->format, $timestamp);
 
+        $isodate = $datetime->format($this->format);
         return $isodate;
     }
 
@@ -58,12 +54,8 @@ class Date extends Field
     {
         $datetime = \DateTime::createFromFormat( $this->format, $humandate);
         if (!$datetime) return null;
-        $timestamp = $datetime->getTimestamp();
-        if ($timestamp < 1) {
-            return null;
-        }
-        $humandate = date('Y-m-d', $timestamp);
 
+        $humandate = $datetime->format('Y-m-d');
         return $humandate;
     }
 


### PR DESCRIPTION
Editing and saving records with date fields before 1970-01-01 causes dates to be discarded(i.e. nullified) since rapyd returns null in case of negative $timestamp.
This should fix the issue.
